### PR TITLE
fix: Missing link to libcurl

### DIFF
--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(influx_component PUBLIC
     ${diagnostic_msgs_TARGETS}
     rclcpp::rclcpp
     rclcpp_components::component
+    CURL::libcurl
 )
 
 ament_export_dependencies(influx_component ${dependencies})


### PR DESCRIPTION
Added CURL::libcurl as a public dependency for the influx_component target to resolve linking errors.